### PR TITLE
Add AMD support

### DIFF
--- a/jquery.omniwindow.js
+++ b/jquery.omniwindow.js
@@ -3,7 +3,17 @@
 // @author:   Rudenka Alexander (mur.mailbox@gmail.com)
 // @license:  MIT
 
-;(function($) {
+;(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], function(jQuery) {
+      return (root.jQuery = factory(jQuery));
+    });
+  } else {
+    // Browser globals
+    factory(root.jQuery);
+  }
+}(this, function($) {
   "use strict";
   $.fn.extend({
     omniWindow: function(options) {
@@ -138,4 +148,6 @@
       });
     }
   });
-})(jQuery);
+
+  return $;
+}));


### PR DESCRIPTION
This pull request adds AMD support using the template supplied by the UMDJS project: https://github.com/umdjs/umd/blob/master/amdWebGlobal.js

This template doesn't changed the existing behaviour. However those who do have an AMD loader, like requirejs, can now use this plugin directly without shimming.
