### PR TITLE
AMD support fix

### DIFF
--- a/jquery.omniwindow.js
+++ b/jquery.omniwindow.js
@@ -5,7 +5,7 @@
 
 ;(function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory(jQuery)); // AMD. Register as anonymous module.
+    define(['jquery'], factory); // AMD. Register as anonymous module.
   } else {
     factory(jQuery); // Browser globals.
   }


### PR DESCRIPTION
Using OmniWindow with require.js did not work properly in our application because the factory function was called directly. Using define(), require.js will call the given factory function providing the defined dependencies (jQuery in this case) as parameters.
